### PR TITLE
Game API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,5 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+#VSCode
+.vscode/

--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+pylint = "*"
 
 [packages]
 numpy = "*"

--- a/gobanana/game/directions.py
+++ b/gobanana/game/directions.py
@@ -9,7 +9,7 @@ class _ConstantList(type):
 
 class Directions(metaclass=_ConstantList):
 	"""Tuples representing Up, Down, Left and Right"""
-	UP = (0, -1)
-	DOWN = (0, 1)
-	LEFT = (-1, 0)
-	RIGHT = (1, 0)
+	UP = (-1, 0)
+	DOWN = (1, 0)
+	LEFT = (0, -1)
+	RIGHT = (0, 1)

--- a/gobanana/game/directions.py
+++ b/gobanana/game/directions.py
@@ -1,0 +1,15 @@
+class _ConstantList(type):
+	"""Metaclass to allow iterating over a list of class members"""
+	def __iter__(self):
+		for attr in vars(self).keys():
+			if not attr.startswith("__"):
+				returnattr = self.__dict__[attr]
+				if not callable(returnattr):
+					yield self.__dict__[attr]
+
+class Directions(metaclass=_ConstantList):
+	"""Tuples representing Up, Down, Left and Right"""
+	UP = (0, -1)
+	DOWN = (0, 1)
+	LEFT = (-1, 0)
+	RIGHT = (1, 0)

--- a/gobanana/game/game.py
+++ b/gobanana/game/game.py
@@ -18,8 +18,8 @@ class Game():
 	def __init__(self, board):
 		assert len(board.shape) == 2, f"The board's dimensionality should be 2. Instead it was {len(board.shape)}"
 		assert board.dtype == np.int, f"The elements of the board should be integers. Instead they were {board.dtype}"
-		assert board.min() >= min(Tiles), f"There are invalid tiles in the given board"
-		assert board.max() <= max(Tiles), f"There are invalid tiles in the given board"
+		assert board.min() >= min(Tiles), f"There are invalid tiles in the given board. The given board is {board}"
+		assert board.max() <= max(Tiles), f"There are invalid tiles in the given board. The given board is {board}"
 		assert all(dim>0 for dim in board.shape), f"Board dimensions must be greater than 0. Board dimensions were {self._board.shape}"
 		self._board = board
 

--- a/gobanana/game/game.py
+++ b/gobanana/game/game.py
@@ -1,0 +1,127 @@
+from typing import Tuple
+
+import copy
+import numpy as np
+
+from gobanana.game.tiles import Tiles
+from gobanana.game.directions import Directions
+from gobanana.game.helpermethods import add_tuples
+
+class Game():
+	"""
+	Class to track the board for a Banana Slip game
+
+	Args:
+		board (np.ndarray): an np.ndarray object. If not specified, dims should be specified.
+	"""
+	
+	def __init__(self, board):
+		assert len(board.shape) == 2, f"The board's dimensionality should be 2. Instead it was {len(board.shape)}"
+		assert board.dtype == np.int, f"The elements of the board should be integers. Instead they were {board.dtype}"
+		assert board.min() >= min(Tiles), f"There are invalid tiles in the given board"
+		assert board.max() <= max(Tiles), f"There are invalid tiles in the given board"
+		assert all(dim>0 for dim in board.shape), f"Board dimensions must be greater than 0. Board dimensions were {self._board.shape}"
+		self._board = board
+
+	@property
+	def board(self):
+		"""The representation of the underlying game board"""
+		return copy.deepcopy(self._board)
+
+	@property
+	def shape(self):
+		"""The dimensions of the board"""
+		return copy.deepcopy(self._board.shape)
+
+	def is_on_board(self, position):
+		"""Returns true if the given position is on the board"""
+		assert len(self.shape) == len(position), f"Can only check to see if the newposition is on the board if newposition has the same number of dimensions as the board"
+		return all(0<=position[i]<self.shape[i] for i in range(len(position)))
+
+	def is_residable(self, position):
+		"""Returns true if the given location is both on the board and not a wall tile (i.e. a valid location for the player to exist)"""
+		assert len(self.shape) == len(position), f"Can only check to see if the position is on the board if position has the same number of dimensions as the board"
+		#Check whether the new position is on the board and is not a wall tile
+		if not self.is_on_board(position):
+			return False
+		if self.board[position] == Tiles.WALL:
+			return False
+		return True
+
+	def is_movable_direction(self, position, direction):
+		"""
+		Returns true if the player can take a step in a given direction from the given position, where the position and direction are tuples,
+		"""
+		newposition = add_tuples(position, direction)
+		return self.is_residable(newposition)
+
+	def moved_player(self, position, direction):
+		"""Returns the position to which a player would reside were they to move."""
+		assert direction in Directions, f"The direction should be one of the directions in {list(Directions)}"
+		assert self.is_movable_direction(position, direction), f"Player cannot move in the provided direction, {Directions(direction)}:{direction}."
+
+		#The first step prior to banana-slipping
+		newposition = add_tuples(position, direction)
+		#If that step was a banana peel, or they started on a banana, keep moving the player until they hit an invalid position
+		if self.board[newposition] == Tiles.BANANA_PEEL or self.board[position] == Tiles.BANANA_PEEL:
+			nextposition = add_tuples(newposition, direction)
+			while self.is_residable(nextposition):
+				newposition = nextposition
+				nextposition = add_tuples(newposition, direction)
+		#Return the final valid position
+		return newposition	
+
+	def child_player_positions(self, position):
+		"""Returns the possible player positions to which a player may move from the given position"""
+		#Check each direction the player can move in and append the position resulting from that movement to a list
+		attainable_positions = []
+		for direction in Directions:
+			if self.is_movable_direction(position, direction):
+				newposition = self.moved_player(position, direction)
+				attainable_positions.append(newposition)
+		#Return the list of player positions resulting from valid movements
+		return attainable_positions
+
+	def is_won(self, position):
+		"""Returns true if the game has been won (the bottom-right corner has been reached)"""
+		return position == add_tuples(self.shape, (-1, -1))
+	
+	def __str__(self):
+		"""Represents the game board using ASCII characters"""
+		return Game.to_string(self)
+
+	@staticmethod
+	def random_game(dims):
+		"""Generates a random game with the provided dimensions"""
+		assert all(1<=dim for dim in dims), f"No dimensions of the game board can be nonpositive. Dims provided: {dims}"
+		assert len(dims)==2, f"The game board should only have width and height. Dims provided: {dims}."
+		board = np.random.choice(a=Tiles, size=dims)
+		board[(0,0)] = Tiles.FLOOR
+		return Game(board)
+
+	@staticmethod
+	def from_string(string):
+		"""Returns a Board/ndarray representation of the provided board-formatted-as-text"""
+		lines = string.splitlines()
+		numrows = len(lines)
+		assert numrows>0, "Cannot read board from string with no lines in in it."
+		numcols = len(lines[0])
+		assert all(len(lines[i]) == numcols for i in range(numrows)), "All rows should have the same length"
+
+		#Form characters into 2D ndarray
+		char_matrix = np.array([[row[col] for col in range(numcols)] for row in lines])
+
+		#Convert characters to integers
+		vectorized_converter = np.vectorize(lambda char: Tiles.from_char(char))
+		convertedboard = vectorized_converter(char_matrix)
+		return Game(convertedboard)
+
+	@staticmethod
+	def to_string(game, position=None):
+		"""Returns an ASCII representation of the board, possibly with a player at the provided position"""
+		vectorized_converter = np.vectorize(lambda x: Tiles(x).character)
+		convertedboard = vectorized_converter(game.board)
+		if position is not None:
+			assert game.is_on_board(position)
+			convertedboard[position] = '@'
+		return '\n'.join(''.join(row) for row in convertedboard)

--- a/gobanana/game/game.py
+++ b/gobanana/game/game.py
@@ -9,7 +9,9 @@ from gobanana.game.helpermethods import add_tuples
 
 class Game():
 	"""
-	Class to track the board for a Banana Slip game
+	Class to track the board for a Banana Slip game. 
+	Unlike StatefulGame from statefulgame.py, this is stateless; that is, the player position
+	is not part of the class, and the class's methods instead take in and return player positions.
 
 	Args:
 		board (np.ndarray): an np.ndarray object. If not specified, dims should be specified.

--- a/gobanana/game/helpermethods.py
+++ b/gobanana/game/helpermethods.py
@@ -1,0 +1,6 @@
+from typing import Tuple
+
+def add_tuples(tuple1: Tuple, tuple2: Tuple):
+	"""Method for adding two tuples together"""
+	assert len(tuple1)==len(tuple2), f"Added tuples must be of equal length. Tuple 1 was {tuple1}, Tuple 2 was {tuple2}"
+	return tuple(map(sum, zip(tuple1, tuple2)))

--- a/gobanana/game/statefulgame.py
+++ b/gobanana/game/statefulgame.py
@@ -39,7 +39,7 @@ class StatefulGame():
 		assert len(self.shape) == len(position), f"Can only check to see if the newposition is on the board if newposition has the same number of dimensions as the board"
 		return all(0<=position[i]<self.shape[i] for i in range(len(position)))
 
-	def is_residable(self, position):
+	def is_inhabitable(self, position):
 		"""Returns true if the given location is both on the board and not a wall tile (i.e. a valid location for the player to exist)"""
 		assert len(self.shape) == len(position), f"Can only check to see if the position is on the board if position has the same number of dimensions as the board"
 		#Check whether the new position is on the board and is not a wall tile
@@ -55,7 +55,7 @@ class StatefulGame():
 		representing the change in coofrom board import Boarddinates from the current position
 		"""
 		newposition = add_tuples(position, direction)
-		return self.is_residable(newposition)
+		return self.is_inhabitable(newposition)
 
 	def moved_player(self, position, direction):
 		"""Returns the position to which a player would reside were they to move."""
@@ -67,7 +67,7 @@ class StatefulGame():
 		#If that step was a banana peel, or they started on a banana, keep moving the player until they hit an invalid position
 		if self.board[newposition] == Tiles.BANANA_PEEL or self.board[position] == Tiles.BANANA_PEEL:
 			nextposition = add_tuples(newposition, direction)
-			while self.is_residable(nextposition):
+			while self.is_inhabitable(nextposition):
 				newposition = nextposition
 				nextposition = add_tuples(newposition, direction)
 		#Return the final valid position

--- a/gobanana/game/statefulgame.py
+++ b/gobanana/game/statefulgame.py
@@ -9,7 +9,9 @@ from gobanana.game.helpermethods import add_tuples
 
 class StatefulGame():
 	"""
-	Class to track the board and player position for a Banana Slip game
+	Class to track the board and player position for a Banana Slip game.
+	Unlike Game from game.py, this is a stateful class; it does not change, but its methods return new StatefulGame objects containing
+	the position of the player, which can then in turn be called upon.
 
 	Args:
 		board (np.ndarray): an np.ndarray object. If not specified, dims should be specified.

--- a/gobanana/game/statefulgame.py
+++ b/gobanana/game/statefulgame.py
@@ -1,0 +1,114 @@
+from typing import Tuple
+
+import copy
+import numpy as np
+
+from gobanana.game.tiles import Tiles
+from gobanana.game.directions import Directions
+from gobanana.game.helpermethods import add_tuples
+
+class StatefulGame():
+	"""
+	Class to track the board and player position for a Banana Slip game
+
+	Args:
+		board (np.ndarray): an np.ndarray object. If not specified, dims should be specified.
+		player (Tuple<int>): The player's cordinates within the board (i.e., (0,0) is the upper-left corner; (0,1) is one spot right.)
+	"""
+	
+	def __init__(self, board):
+		assert len(board.shape) == 2, f"The board's dimensionality should be 2. Instead it was {len(board.shape)}"
+		assert board.dtype == np.int, f"The elements of the board should be integers. Instead they were {board.dtype}"
+		assert board.min() >= min(Tiles), f"There are invalid tiles in the given board"
+		assert board.max() <= max(Tiles), f"There are invalid tiles in the given board"
+		assert all(dim>0 for dim in board.shape), f"Board dimensions must be greater than 0. Board dimensions were {self._board.shape}"
+		self._board = board
+
+	@property
+	def board(self):
+		"""The representation of the underlying game board, sans the player"""
+		return copy.deepcopy(self._board)
+
+	@property
+	def shape(self):
+		"""The dimensions of the board"""
+		return copy.deepcopy(self._board.shape)
+
+	def is_on_board(self, position):
+		"""Returns true if the given position is on the board"""
+		assert len(self.shape) == len(position), f"Can only check to see if the newposition is on the board if newposition has the same number of dimensions as the board"
+		return all(0<=position[i]<self.shape[i] for i in range(len(position)))
+
+	def is_residable(self, position):
+		"""Returns true if the given location is both on the board and not a wall tile (i.e. a valid location for the player to exist)"""
+		assert len(self.shape) == len(position), f"Can only check to see if the position is on the board if position has the same number of dimensions as the board"
+		#Check whether the new position is on the board and is not a wall tile
+		if not self.is_on_board(position):
+			return False
+		if self.board[position] == Tiles.WALL:
+			return False
+		return True
+
+	def is_movable_direction(self, position, direction):
+		"""
+		Returns true if the player can take a step in a given direction, where the direction is a tuple
+		representing the change in coofrom board import Boarddinates from the current position
+		"""
+		newposition = add_tuples(position, direction)
+		return self.is_residable(newposition)
+
+	def moved_player(self, position, direction):
+		"""Returns the position to which a player would reside were they to move."""
+		assert direction in Directions, f"The direction should be one of the directions in {list(Directions)}"
+		assert self.is_movable_direction(position, direction), f"Player cannot move in the provided direction, {Directions(direction)}:{direction}."
+
+		#The first step prior to banana-slipping
+		newposition = add_tuples(position, direction)
+		#If that step was a banana peel, or they started on a banana, keep moving the player until they hit an invalid position
+		if self.board[newposition] == Tiles.BANANA_PEEL or self.board[position] == Tiles.BANANA_PEEL:
+			nextposition = add_tuples(newposition, direction)
+			while self.is_residable(nextposition):
+				newposition = nextposition
+				nextposition = add_tuples(newposition, direction)
+		#Return the final valid position
+		return newposition	
+
+	def child_player_positions(self, position):
+		"""Returns the possible player positions to which a player may move from this point"""
+		#Check each direction the player can move in and append the position resulting from that movement to a list
+		attainable_positions = []
+		for direction in Directions:
+			if self.is_movable_direction(position, direction):
+				newposition = self.moved_player(position, direction)
+				attainable_positions.append(newposition)
+		#Return the list of player positions resulting from valid movements
+		return attainable_positions
+
+	def child_games(self, position):
+		"""Returns the possible games that result from a player move from this point"""
+		#Take each position resulting from valid movements and create a new corresponding game object
+		available_games = []
+		for child_position in self.child_player_positions(position):
+			available_games.append(StatefulGame(self._board, child_position))
+		#Return the list of available 
+		return available_games
+
+	def is_won(self, position):
+		"""Returns true if the game has been won (the bottom-right corner has been reached)"""
+		return position == add_tuples(self.shape, (-1, -1))
+	
+	def __str__(self, position):
+		"""Represents the game using ascii characters"""
+		vectorized_converter = np.vectorize(lambda x: Tiles(x).character)
+		convertedboard = vectorized_converter(self._board)
+		convertedboard[position] = '@'
+		return '\n'.join(''.join(row) for row in convertedboard)
+
+	@staticmethod
+	def random_game(dims):
+		"""Generates a random game with the provided dimensions"""
+		assert all(1<=dim for dim in dims), f"No dimensions of the game board can be nonpositive. Dims provided: {dims}"
+		assert len(dims)==2, f"The game board should only have width and height. Dims provided: {dims}."
+		board = np.random.choice(a=Tiles, size=dims)
+		board[(0,0)] = Tiles.FLOOR
+		return StatefulGame(board, (0,0))

--- a/gobanana/game/tiles.py
+++ b/gobanana/game/tiles.py
@@ -1,0 +1,45 @@
+from enum import IntEnum, unique, EnumMeta
+from collections import defaultdict
+
+class TilesMeta(EnumMeta):
+	_reverse_spritename_lookup = defaultdict(lambda: -1)
+	_reverse_character_lookup = defaultdict(lambda: -1)
+
+@unique
+class Tiles(IntEnum, metaclass=TilesMeta):
+	"""Enumerated constants for holding information about tiles"""
+	FLOOR 		= 0, 'floor', '.'
+	WALL		= 1, 'wall', '#'
+	BANANA_PEEL	= 2, 'banana', '^'
+
+	def __new__(cls, keycode, spritename=None, character = None):
+		obj = int.__new__(cls, keycode)
+		obj._value_ = keycode
+
+		if spritename is not None:
+			obj.spritename = spritename
+			cls._reverse_spritename_lookup[spritename] = obj
+		else:
+			obj.spritename = 'unknown'
+
+		if character is not None:
+			obj.character = character
+			cls._reverse_character_lookup[character] = obj
+		else:
+			obj.character = '?'		
+		return obj	
+
+	@classmethod
+	def from_sprite(cls, sprite):
+		"""Returns the tile associated with this sprite name"""
+		return cls._reverse_spritename_lookup[sprite]
+	
+	@classmethod
+	def from_char(cls, char):
+		"""Returns the tile associated with this character"""
+		return cls._reverse_character_lookup[char]
+
+	@classmethod
+	def values(cls):
+		"""Returns a list of the enumerated constants' underlying values"""
+		return [key.value for key in cls]

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,0 +1,158 @@
+import unittest
+
+import numpy as np
+
+from gobanana.game.game import Game
+from gobanana.game.tiles import Tiles
+from gobanana.game.directions import Directions
+from gobanana.game.helpermethods import add_tuples
+
+class Test_Board_Legality(unittest.TestCase):
+	"""Test methods to check on functions that have to do with board position legality"""
+
+	def test_is_on_board(self):
+		game = Game.random_game((6, 6))
+		self.assertFalse(game.is_on_board((0, -1)))
+		self.assertFalse(game.is_on_board((-1, 0)))
+		self.assertTrue(game.is_on_board((0, 0)))
+		self.assertTrue(game.is_on_board((3, 4)))
+		self.assertFalse(game.is_on_board((7, 6)))
+		self.assertFalse(game.is_on_board((6, 7)))
+		self.assertTrue(game.is_on_board((5, 5)))
+
+	def test_is_residable(self):
+		gamestring = np.array([[Tiles.FLOOR, Tiles.FLOOR, Tiles.FLOOR],\
+		                       [Tiles.FLOOR, Tiles.WALL, Tiles.FLOOR],\
+		                       [Tiles.FLOOR, Tiles.FLOOR, Tiles.BANANA_PEEL]])
+		game = Game(gamestring)
+
+		badloc = (1,1)
+		coordslist = []
+		for i in range(game.board.shape[0]):
+			for j in range(game.board.shape[1]):
+				coordslist.append((i, j))
+		
+		for (i, j) in coordslist:
+			fred = Tiles(game.board[(i, j)])
+			if (i, j) != (1,1):
+				self.assertTrue(game.is_residable((i, j)))
+			else:
+				self.assertFalse(game.is_residable((i, j)))
+
+	def test_is_movable_direction(self):
+		gamearray = np.array([[Tiles.FLOOR, Tiles.FLOOR, Tiles.FLOOR],\
+		                       [Tiles.FLOOR, Tiles.WALL, Tiles.FLOOR],\
+		                       [Tiles.FLOOR, Tiles.FLOOR, Tiles.BANANA_PEEL]])
+		game = Game(gamearray)
+
+		fred = game.board[(1,2)]
+		self.assertFalse(game.is_movable_direction((1, 2), Directions.LEFT))
+		self.assertTrue(game.is_movable_direction((1,2), Directions.UP))
+		self.assertTrue(game.is_movable_direction((1,2), Directions.DOWN))
+		self.assertFalse(game.is_movable_direction((1, 2), Directions.RIGHT))
+
+		self.assertFalse(game.is_movable_direction((1, 0), Directions.LEFT))
+		self.assertTrue(game.is_movable_direction((1,0), Directions.UP))
+		self.assertTrue(game.is_movable_direction((1,0), Directions.DOWN))
+		self.assertFalse(game.is_movable_direction((1, 0), Directions.RIGHT))
+
+		self.assertTrue(game.is_movable_direction((2, 2), Directions.LEFT))
+		self.assertTrue(game.is_movable_direction((2,2), Directions.UP))
+		self.assertFalse(game.is_movable_direction((2,2), Directions.DOWN))
+		self.assertFalse(game.is_movable_direction((2, 2), Directions.RIGHT))
+
+class Test_Player_Miscellaneous(unittest.TestCase):
+	"""Test methods to check miscellaneous things"""
+
+	def test_player_won(self):
+		gamearray = np.array([[Tiles.FLOOR, Tiles.FLOOR, Tiles.FLOOR],\
+						[Tiles.FLOOR, Tiles.WALL, Tiles.FLOOR],\
+						[Tiles.FLOOR, Tiles.FLOOR, Tiles.BANANA_PEEL]])
+		game = Game(gamearray)
+		self.assertTrue(game.is_won((2, 2)))
+		self.assertFalse(game.is_won((2, 1)))
+		self.assertFalse(game.is_won((0, 0)))
+
+		gamearray = np.array([[Tiles.FLOOR, Tiles.BANANA_PEEL, Tiles.FLOOR, Tiles.FLOOR],\
+		                      [Tiles.FLOOR, Tiles.WALL, Tiles.FLOOR, Tiles.FLOOR],\
+		                      [Tiles.WALL, Tiles.FLOOR, Tiles.BANANA_PEEL, Tiles.FLOOR]])
+		game = Game(gamearray)
+		self.assertTrue(game.is_won((2, 3)))
+		self.assertFalse(game.is_won((2, 2)))
+		self.assertFalse(game.is_won((0, 0)))	
+
+class Test_Player_Movement(unittest.TestCase):
+	"""Test methods to check on the player movement functions"""
+
+	def test_moved_player(self):
+		gamearray = np.array([[Tiles.FLOOR, Tiles.BANANA_PEEL, Tiles.FLOOR, Tiles.FLOOR],\
+		                      [Tiles.FLOOR, Tiles.WALL, Tiles.FLOOR, Tiles.FLOOR],\
+		                      [Tiles.WALL, Tiles.FLOOR, Tiles.BANANA_PEEL, Tiles.FLOOR]])
+		game = Game(gamearray)
+
+		self.assertEqual(game.moved_player((2, 3), Directions.LEFT), (2, 1))
+		self.assertEqual(game.moved_player((2, 2), Directions.LEFT), (2, 1))
+		self.assertEqual(game.moved_player((2, 2), Directions.UP), (0, 2))
+		self.assertEqual(game.moved_player((0, 1), Directions.RIGHT), (0, 3))
+		self.assertEqual(game.moved_player((0, 1), Directions.LEFT), (0, 0))
+
+	def test_child_position(self):
+		gamearray = np.array([[Tiles.FLOOR, Tiles.BANANA_PEEL, Tiles.FLOOR, Tiles.FLOOR],\
+		                     [Tiles.FLOOR, Tiles.WALL, Tiles.FLOOR, Tiles.FLOOR],\
+		                     [Tiles.WALL, Tiles.FLOOR, Tiles.BANANA_PEEL, Tiles.FLOOR]])
+		game = Game(gamearray)
+
+		self.assertTrue( sorted(game.child_player_positions((2, 3))) == sorted([(2, 1), (1, 3)]))
+		self.assertTrue( sorted(game.child_player_positions((2, 2))) == sorted([(2, 1), (2, 3), (0, 2)]))
+
+class Test_Game_String_Conversions(unittest.TestCase):
+	"""Test methods that have to do with string conversions"""
+
+
+	def test_from_string(self):
+		game = Game.from_string(\
+f"""\
+{Tiles.WALL.character*2}{Tiles.BANANA_PEEL.character*3}
+{Tiles.BANANA_PEEL.character*5}
+{Tiles.FLOOR.character*5}
+{Tiles.WALL.character*2}{Tiles.BANANA_PEEL.character*1}{Tiles.FLOOR.character*2}
+{Tiles.BANANA_PEEL.character*2}{Tiles.WALL.character*3}
+""")
+		wall_locs = [(0,0), (0, 1), (3, 0), (3, 1), (4, 2), (4, 3), (4, 4)]
+		floor_locs = [(2, 0), (2, 1), (2, 2), (2, 3), (2, 4)]
+		banana_locs = [(0, 2), (0, 3), (0, 4), (3, 2), (4, 0), (4,1)]
+		for wall_loc in wall_locs:
+			self.assertEqual(Tiles.WALL, game.board[wall_loc])
+		for floor_loc in floor_locs:
+			self.assertEqual(Tiles.FLOOR, game.board[floor_loc])
+		for banana_loc in banana_locs:
+			self.assertEqual(Tiles.BANANA_PEEL, game.board[banana_loc])
+
+		print(game.board)
+
+	def test_to_string(self):
+		board =np.array(\
+		            [[Tiles.WALL, Tiles.WALL, Tiles.BANANA_PEEL, Tiles.BANANA_PEEL, Tiles.BANANA_PEEL],\
+		        	 [Tiles.BANANA_PEEL, Tiles.BANANA_PEEL, Tiles.BANANA_PEEL, Tiles.BANANA_PEEL, Tiles.BANANA_PEEL],\
+		        	 [Tiles.FLOOR, Tiles.FLOOR, Tiles.FLOOR, Tiles.FLOOR, Tiles.FLOOR],\
+		        	 [Tiles.WALL, Tiles.WALL, Tiles.BANANA_PEEL, Tiles.FLOOR, Tiles.FLOOR],\
+		        	 [Tiles.BANANA_PEEL, Tiles.BANANA_PEEL, Tiles.WALL, Tiles.WALL, Tiles.WALL]])
+		
+		game = Game(board)
+
+		gamestring1 = Game.to_string(game)
+		gamestring2 =\
+f"""\
+{Tiles.WALL.character*2}{Tiles.BANANA_PEEL.character*3}
+{Tiles.BANANA_PEEL.character*5}
+{Tiles.FLOOR.character*5}
+{Tiles.WALL.character*2}{Tiles.BANANA_PEEL.character*1}{Tiles.FLOOR.character*2}
+{Tiles.BANANA_PEEL.character*2}{Tiles.WALL.character*3}"""
+
+		self.assertEqual(gamestring1, gamestring2, f"To-string failed. \ngamestring1:\n{gamestring1}. \ngamestring2:\n{gamestring2}")
+	
+
+	
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Created two Game classes- `game.py` and `statefulgame.py`- to run game logic and give state transitions. The latter, stateful version was originally was created to satisfy https://github.com/TeamGorilla/GoBanana/issues/3#issue-573852841, while the former was created in case we prefer a fully stateless version.

 `Game` in `game.py` is stateless; it holds a board (a numpy.ndarray), and all of its methods take in a position and return a position/list of positions (as tuples). 

`StatefulGame` in `statefulgame.py`, on the other hand, while immutable, tracks position. As such, its methods assume the contained player position and output new `StatefulGame` objects with different player positions.

Both classes contain methods to get all of the children positions/boards-with-positions from a board-and-position combination.